### PR TITLE
Some bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ new SpikeDatoCMS({
 })
 ```
 
+### Aggressive Refresh
+
+By default, this plugin will only fetch data once when you start your watcher, for development speed purposes. This means that if you change your data, you will have to restart the watcher to pick up the changes. If you are in a phase where you are making frequent data changes and would like a more aggressive updating strategy, you can set the `aggressiveRefresh` option to `true`, and your dreams will come true. However, note that this will slow down your local development, as it will fetch and link all entires every time you save a file, so it's only recommended for temporary use.
+
 ### Local Cache
 
 > :rotating_light: Please understand this section thoroughly before attempting to use the `cache` feature

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,6 +54,7 @@ module.exports = class SpikeDatoCMS {
   }
 
   run (compilation, done) {
+    if (this.addDataTo.dato && !this.aggressiveRefresh) return done()
     return W.all([
       fetchData.call(this),
       W.reduce(this.models, (memo, model) => {
@@ -85,7 +86,8 @@ module.exports = class SpikeDatoCMS {
           .yield(memo)
       }, {})
     ]).done(([site, models]) => {
-      // add to the locals
+      // clear existing locals, add new data
+      if (this.addDataTo.dato) { delete this.addDataTo.dato }
       Object.assign(this.addDataTo, { dato: Object.assign(models, { _meta: site }) })
       done()
     }, done)


### PR DESCRIPTION
- Metadata was continuously added to as reported by @elvingm, clearing the object between runs should take care of this
- Data was fetched every save causing slowness as reported by @kylemac, changing the behavior such that it's only fetched once on initial compile, and allowing more aggressive fetching through an `aggressiveRefresh` option should take care of this