### PR TITLE
bump datocms-client to v0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "bugs": "https://github.com/static-dev/spike-datocms/issues",
   "dependencies": {
-    "datocms-client": "^0.4.6",
+    "datocms-client": "^0.5.2",
     "es6bindall": "^0.0.9",
     "joi": "^13.2.0",
     "spike-util": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1714,9 +1714,9 @@ date-time@^2.1.0:
   dependencies:
     time-zone "^1.0.0"
 
-datocms-client@^0.4.6:
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/datocms-client/-/datocms-client-0.4.6.tgz#9e7bfa2f9181d4afeb4970e38393880dc52b1ccc"
+datocms-client@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/datocms-client/-/datocms-client-0.5.2.tgz#d99699faa0c7e89577fcacc39a7f996a714e3d06"
   dependencies:
     babel-polyfill "6.16.0"
     chokidar "^1.6.1"


### PR DESCRIPTION
Due to the breaking change in Dato's API introduced last month, this package is currently broken. Anybody trying to compile a project with this plugin will encounter the following error after running `spike [watch|compile]`:

`FetchError: request to https://site-api.datocms.com/site failed, reason: getaddrinfo ENOTFOUND site-api.datocms.com site-api.datocms.com:443`

Fixed by bumping the version 😅 